### PR TITLE
Changed from bootstrap to bootstrap-bundle and updated gulpfile.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,7 +11,7 @@ gulp.task('sass', function() {
 
 // Move JS files to public javascripts directory.
 gulp.task('js', function() {
-  return gulp.src(['node_modules/bootstrap/dist/js/bootstrap.min.js',
+  return gulp.src(['node_modules/bootstrap/dist/js/bootstrap.bundle.min.js',
     'node_modules/jquery/dist/jquery.min.js',
     'node_modules/tether/dist/js/tether.min.js',
     'node_modules/popper.js/dist/popper.min.js',
@@ -26,14 +26,14 @@ gulp.task('jest', function() {
   process.env.DATABASE_URL = 'postgres://group16:abc123@localhost:5433/postgres';
   return gulp.src('__tests__').pipe(jest({
     'preprocessorIgnorePatterns': [
-      'public/javascripts/bootstrap.min.js',
+      'public/javascripts/bootstrap.bundle.min.js',
       'public/javascripts/jquery.min.js',
       'public/javascripts/tether.min.js',
       'node_modules/',
     ],
     'collectCoverage': true,
     'coveragePathIgnorePatterns': [
-      'public/javascripts/bootstrap.min.js',
+      'public/javascripts/bootstrap.bundle.min.js',
       'public/javascripts/jquery.min.js',
       'public/javascripts/tether.min.js',
       'node_modules/',

--- a/view/bootstrap/js.ejs
+++ b/view/bootstrap/js.ejs
@@ -1,3 +1,10 @@
 <script src="/javascripts/popper.min.js"></script>
 <script src="/javascripts/jquery.min.js"></script>
-<script src="/javascripts/bootstrap.min.js"></script>
+<script src="/javascripts/bootstrap.bundle.min.js"></script>
+
+<!-- Globally initialize Bootstrap tooltips -->
+<script>
+$(function () {
+  $('[data-toggle="tooltip"]').tooltip()
+})
+</script>

--- a/view/components/tool-checklist.ejs
+++ b/view/components/tool-checklist.ejs
@@ -39,17 +39,18 @@
             </div>
             <!-- Some form of directional input, probably just number -360 to 360 -->
             <div class="form-group pl-3">
-                <label for="flipDir">Flip Direction <small>(Degrees rotating clockwise)</small></label>
-                <select class="form-control" id="flipDir" name="flipDir">
+               <div> <label for="flipDir">Flip Direction </label> <i class="fas fa-info-circle" data-toggle="tooltip" data-placement="top" title="If a table on a particular page is presented sideways instead of horizontally, the “Extract all Tables” tool will have a difficult time extracting it. You can fix this by using the tool to rotate the table in degrees (clockwise)."></i> </div>
+               <select class="form-control" style="display: inline-block;" id="flipDir" name="flipDir">
                     <option value="0">0</option>
                     <option value="90">90</option>
                     <option value="180">180</option>
                     <option value="270">270</option>
                 </select>
+                <small>(Degrees rotating clockwise)</small>
             </div>
         
             <!-- will discuss further when/if we get to it -->
-            <h5><strong>Coordinates:</strong></h5>
+            <h5><strong>Coordinates:</strong> <i class="fas fa-info-circle" data-toggle="tooltip" data-placement="top" title="To find the coordinates using MacOs, you can use the Preview application. Open the PDF in Preview, then scroll to the page of the table you are trying to extract. Under the 'Tools' menu option, select 'Show Inspector'"></i> </h5>
             <div class="row">
                 <div class="col">
                     <div class="form-group">


### PR DESCRIPTION
Added tooltips to explain each feature.
Made degree rotation text inline with select box.
=======================================
Testing:
Re-run gulp for sass and js (gulp js). This should bring in the bootstrap bundle dependancy.

Navigate to http://127.0.0.1:3001/data-entry
Click "Extract Tables by Page"