### PR TITLE
Fixed "number" disappearing when update is spammed

### DIFF
--- a/public/javascripts/tool.js
+++ b/public/javascripts/tool.js
@@ -225,10 +225,13 @@ $('#event-div').on('click', 'a.table-control-update', function() {
   const options = {};
   options.command = $(this).siblings('select.command').val();
   options.type = $(this).siblings('select.type').val();
+  options.rowNumber = $(this).siblings('select.row-number').val();
+  options.colNumber = $(this).siblings('select.col-number').val()
+  
   const table = $(this).closest('div.collapse').siblings('table');
 
   // Execute specified command
-  if (options.type === 'row') {
+  if (options.type === 'row' && options.rowNumber != 'Number') {
     const select = $(this).siblings('select.row-number');
     options.number = select.val();
 
@@ -243,7 +246,7 @@ $('#event-div').on('click', 'a.table-control-update', function() {
         $(this).parent().siblings('div.table-alert-target').html(tableAlert);
       }
     }
-  } else if (options.type === 'column') {
+  } else if (options.type === 'column'  && options.colNumber != 'Number') {
     const select = $(this).siblings('select.col-number');
     options.number = select.val();
     if ( options.command === 'add' ) {


### PR DESCRIPTION
I fixed the underlying issue that was making the "number" field disappear when the update button is spammed.

To test:

Open old version > Data Entry > with PDF > Pick a PDF (I used Wasson_2010) > Extract All Tables > Submit > Wait for tables to load... > Toggle Table Controls > Set "Add/Del" to Delete > Spam update

Repeat with this commit.