### PR TITLE
US47: Properly display password after editing

### DIFF
--- a/public/javascripts/profile.js
+++ b/public/javascripts/profile.js
@@ -33,9 +33,10 @@ $(document).ready(function() {
     } else {
       $('#confirm_password').attr('hidden', true);
       $('#confirmLabel').attr('hidden', true);
-      $('#password').attr('hidden', true);
+      $('#password').attr('hidden', false);
       $('#passwordLabel').attr('hidden', true);
-      $('#password').val('');
+      $('#password').val('************');
+      $('#password').attr('readonly', true);
       $('#confirm_password').val('');
       $('#save-btn').attr('disabled', false);
     }


### PR DESCRIPTION
## Objective
Properly display password field after updating it. 

## Detailed Description
Previously, if you updated (or attempted to update) your password on the website, the password field would entirely disappear. Added a quick fix to display a placeholder value instead.

## Screenshot (if applicable)
![password-fix](https://user-images.githubusercontent.com/40260591/67449495-3784db80-f5cf-11e9-832c-9885117ecdb8.jpg)

## How to Test (if applicable)
1. 🏗 & 🏃 the web app.
2. Login to an account _(or create account if necessary)_
3. Tap the `Account` button in the top right section of the nav bar.
4. Tap `Edit` to change your profile.
5. Check the `Update Password?` checkbox.
6. Enter a new password and tap `Save` **OR** Uncheck the `Update Password?` checkbox.
7. Observe a password field with a placeholder value.

## Requirements
[Taiga User Story](https://tree.taiga.io/project/cbrobsto-iron-db/us/47)
[Taiga Task](https://tree.taiga.io/project/cbrobsto-iron-db/task/101)