### PR TITLE
US117 Fixed name size comparison

### DIFF
--- a/iron.sh
+++ b/iron.sh
@@ -138,7 +138,7 @@ function set_creds ()
     size=${#name}
     if [[ "$name" =~ [^a-zA-Z0-9\_] ]] || [[ "$name" == "$NORESP" ]] || [[ "${name:0:1}" =~ [^a-zA-Z] ]] ; then
       echo "Must start with a letter. Only letters, numbers, and underscore allowed"
-    elif [[ $size < 3 ]]; then
+    elif [[ $size -lt 3 ]]; then
       echo "${name} is too short, minimum of 3 characters"
     else 
       break

--- a/public/javascripts/profile.js
+++ b/public/javascripts/profile.js
@@ -71,12 +71,14 @@ function validatePassword() {
         const hasNumbers = /\d/.test(pwd);
 
         if (!hasUpperCase) {
-          $('.passwordError').text('Password must contain at least 1 upper case character!');
+          $('.passwordError').text(
+              'Password must contain at least 1 upper case character!');
           $('.passwordError').show();
         }
 
         if (!hasLowerCase) {
-          $('.passwordError').text('Password must contain at least 1 lower case character!');
+          $('.passwordError').text(
+              'Password must contain at least 1 lower case character!');
           $('.passwordError').show();
         }
 

--- a/public/javascripts/tool.js
+++ b/public/javascripts/tool.js
@@ -226,8 +226,8 @@ $('#event-div').on('click', 'a.table-control-update', function() {
   options.command = $(this).siblings('select.command').val();
   options.type = $(this).siblings('select.type').val();
   options.rowNumber = $(this).siblings('select.row-number').val();
-  options.colNumber = $(this).siblings('select.col-number').val()
-  
+  options.colNumber = $(this).siblings('select.col-number').val();
+
   const table = $(this).closest('div.collapse').siblings('table');
 
   // Execute specified command
@@ -246,7 +246,7 @@ $('#event-div').on('click', 'a.table-control-update', function() {
         $(this).parent().siblings('div.table-alert-target').html(tableAlert);
       }
     }
-  } else if (options.type === 'column'  && options.colNumber != 'Number') {
+  } else if (options.type === 'column' && options.colNumber != 'Number') {
     const select = $(this).siblings('select.col-number');
     options.number = select.val();
     if ( options.command === 'add' ) {


### PR DESCRIPTION
## Objective
Fix the name size comparison in 'iron.sh -i' when creating a new user name.

## Detailed Description
The minimum number of characters for a new user when using './iron.sh -i' is suppose to be 3 characters, but right now it is bugged. A new user name can be created that is between 3-9 characters long, but when creating a username that is 10 characters long or more, it displays a "[username] is too short, minimum of 3 characters" message. This pull request fixes that bug and allows the creation of user names that are 10 characters or longer. Some style changes were also made in order to pass 'npm test'.

## Screenshot (if applicable)
Before
![image](https://user-images.githubusercontent.com/47923772/68099863-1ac78e00-fe82-11e9-974e-56acf049a0a9.png)
After
![image](https://user-images.githubusercontent.com/47923772/68099890-48143c00-fe82-11e9-877e-6b5a19c37377.png)

## How to Test (if applicable)

1. Navigate to root folder in a command prompt
2. run './iron.sh -i'
3. When prompted to select a new user name, enter a name that is >= 10 characters

## Tests (if added)
N/A

## Requirements
[Taiga User Story](https://tree.taiga.io/project/cbrobsto-iron-db/us/117)
[Taiga Task](https://tree.taiga.io/project/cbrobsto-iron-db/task/118)
