### PR TITLE
US291: Fix Authentication Bug

### DIFF
--- a/API/controller/app.js
+++ b/API/controller/app.js
@@ -113,8 +113,7 @@ app.use(session({
   resave: false,
   saveUninitialized: false,
   // maxAge set to 60 mins, param in miliseconds
-  cookie: {maxAge: 60 * 60 * 1000},
-  expires: new Date(Date.now() + 60 * 60 * 1000)
+  cookie: {maxAge: 60 * 60 * 1000}
 }));
 
 app.use(passport.initialize());

--- a/API/controller/app.js
+++ b/API/controller/app.js
@@ -109,11 +109,12 @@ app.use(cookieParser());
 app.use(express.static(path.join(__dirname, '../public')));
 
 app.use(session({
-  secret: 'P90r*_7QZZt+VR7qJidMGaw)eOxza+IM',
+  secret: '=dh=1QODsu67^LT2X!g0+nu=0^jc+fk0',
   resave: false,
   saveUninitialized: false,
   // maxAge set to 60 mins, param in miliseconds
   cookie: {maxAge: 60 * 60 * 1000},
+  expires: new Date(Date.now() + 60 * 60 * 1000)
 }));
 
 app.use(passport.initialize());

--- a/client/src/components/Auth.jsx
+++ b/client/src/components/Auth.jsx
@@ -19,13 +19,11 @@ const Auth = {
     isAuthenticated: hasSessionCookie(),
 
     login(callback) {
-        console.log('Login called, isAuthenticated is set to true')
         this.isAuthenticated = true;
         setTimeout(callback, 100); //simulate asynchronous code
     },
 
     logout(callback) {
-        console.log('Logout called, isAuthenticated is set to false')
         this.isAuthenticated = false;
         setTimeout(callback, 100); //simulate asynchronous code
     }

--- a/client/src/components/Auth.jsx
+++ b/client/src/components/Auth.jsx
@@ -1,12 +1,34 @@
+/**
+ * Auth provides our React App a single source of truth on the client side
+ * as to whether or not the user is currently logged in or out. It also 
+ * simulates asynchronous logins and logouts. 
+ * 
+ * On app startup, in order to determine if the user is currently logged in
+ * from a previous browser session, we check for the presence of a username
+ * cookie that is set upon successful authentication. If that cookie is present
+ * we assume the user is logged in and we allow access to protected routes.
+ */
+
+import * as Cookies from "js-cookie";
+
+function hasSessionCookie() {
+    return Cookies.get('username') != undefined
+}
+
 const Auth = {
-    isAuthenticated: false,
+    isAuthenticated: hasSessionCookie(),
+
     login(callback) {
-      this.isAuthenticated = true;
-      setTimeout(callback, 100); //simulate asynchronous code
+        console.log('Login called, isAuthenticated is set to true')
+        this.isAuthenticated = true;
+        setTimeout(callback, 100); //simulate asynchronous code
     },
+
     logout(callback) {
-      this.isAuthenticated = false;
-      setTimeout(callback, 100); //simulate asynchronous code
+        console.log('Logout called, isAuthenticated is set to false')
+        this.isAuthenticated = false;
+        setTimeout(callback, 100); //simulate asynchronous code
     }
-  }
-  export default Auth;
+}
+
+export default Auth;

--- a/client/src/components/pages/Login.jsx
+++ b/client/src/components/pages/Login.jsx
@@ -29,7 +29,7 @@ const Login = props => {
                     
                
                     const data = { username: username, password: password }
-                    fetch("/login", {
+                    fetch("/api/login", {
                       method: 'POST',
                       body: JSON.stringify(data),
                       headers:{ 'Content-Type': 'application/json' }

--- a/client/src/components/pages/Register.jsx
+++ b/client/src/components/pages/Register.jsx
@@ -97,7 +97,7 @@ class Register extends React.Component {
 
     console.log("doRegister() => "+payload.username);
 
-    fetch("/register",{
+    fetch("/api/register",{
         method: 'POST',
         body: JSON.stringify(payload),
         headers:{ 'Content-Type': 'application/json' }


### PR DESCRIPTION
## Objective
Fix an authentication bug.

## Detailed Description
There was a weird authentication bug that would prevent authenticated user sessions to persist over browser sessions. Originally I tried to make some changes to the session cookie produced by our backend API thinking this was perhaps an express-session issue. 

It turns out that this was in fact a client side issue. We use the `Auth` component as a source of truth to determine authentication state. On app startup, we were setting `isAuthenticated = false` by default thereby ignoring the presence of any auth cookies that was present in the browser from a previous session.

This made the fix relatively simple. Rather than setting the default value as false, we just check to see if a `username` cookie is present and use that to determine our initial authentication state.

## How to Test (if applicable)
1. Navigate to `http://localhost:8001` and sign into an account.
2. Navigate to a protected route (eg. panel or data entry).
3. Refresh the page, observe you are still authenticated and are on the protected page.

## Requirements
[Taiga User Story](https://tree.taiga.io/project/cbrobsto-iron-db/us/291)
[Taiga Task](https://tree.taiga.io/project/cbrobsto-iron-db/task/292)